### PR TITLE
:rocket: Automatically close and release sonatype staging repository after publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
             build/libs/java-security-*.jar
 
       - name: "Publish to Maven Central"
-        run: ./gradlew publish
+        run: ./gradlew publishNebulaPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSPHRASE }}


### PR DESCRIPTION
Following conventions from codemodder-java 

See https://github.com/gradle-nexus/publish-plugin#behind-the-scenes for details

- automatically "close" the nexus staging repository which finalizes the artifacts and prevents new uploads to the staging repo but does not release it to maven central
- automatically "release" the nexus staging repository which sends the artifacts to maven central for distribution