### PR TITLE
:sparkles: publish a single zip with signatures and MD5s that can be directly published on central.sonatype.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Execute Gradle build
-        run: ./gradlew -Pversion=${{ inputs.version }} build publishToMavenLocal
+        run: ./gradlew -Pversion=${{ inputs.version }} build zipRelease
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSPHRASE }}
@@ -38,4 +38,4 @@ jobs:
           automatic_release_tag: "${{ inputs.version }}"
           prerelease: false
           files: |
-            /home/runner/.m2/repository/io/github/pixee/java-security-toolkit/${{ inputs.version }}/*
+            build/distributions/java-security-toolkit.zip

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,23 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "build"
+            url = uri(layout.buildDirectory.dir("repos/releases"))
+        }
+    }
+}
+
+
+tasks.register<Zip>("zipRelease") {
+    dependsOn("publishAllPublicationsToBuildRepository")
+    from(layout.buildDirectory.dir("repos/releases")) {
+        exclude("**/maven-metadata.xml")
+        exclude("**/maven-metadata.xml*")
+    }
+    archiveFileName.set("java-security-toolkit.zip")
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION

This builds a single file in the following shape we can upload directly to sonatype central
```
unzip -l build/distributions/java-security-toolkit.zip
Archive:  build/distributions/java-security-toolkit.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  12-12-2024 11:36   io/
        0  12-12-2024 11:36   io/github/
        0  12-12-2024 11:36   io/github/pixee/
        0  12-12-2024 11:36   io/github/pixee/java-security-toolkit/
        0  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.asc.sha256
    55612  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.sha1
      821  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.asc
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.asc.md5
      821  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.asc
     5535  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.asc.sha512
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.asc.sha512
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.asc.md5
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.asc.sha256
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.sha1
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.sha1
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.sha256
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.md5
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.sha256
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.md5
   386107  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.asc.md5
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.asc.sha1
      821  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.asc
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.sha512
    33576  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar
     1858  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.sha256
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.sha512
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.asc.sha256
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.md5
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.asc.sha1
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.sha1
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.sha512
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.sha512
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.asc.sha512
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.asc.sha512
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.asc.sha1
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.asc.md5
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.asc.sha256
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.asc.sha256
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.asc.sha1
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.pom.sha512
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.sha256
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.asc.md5
      128  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.asc.sha512
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.md5
       32  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.md5
       64  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.sha256
      821  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.module.asc
      821  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-sources.jar.asc
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0-javadoc.jar.sha1
       40  12-12-2024 11:36   io/github/pixee/java-security-toolkit/0.3.0/java-security-toolkit-0.3.0.jar.asc.sha1
---------                     -------
   489433                     55 files```

