### PR TITLE
Remove unused JSAP dependency (LGPL)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,6 @@ java {
 }
 
 dependencies {
-    api("com.martiansoftware:jsap:2.1")
     api("commons-io:commons-io:2.19.0")
     java11SourceSet.apiConfigurationName("commons-io:commons-io:2.19.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")


### PR DESCRIPTION
## Summary
- Remove unused `com.martiansoftware:jsap:2.1` dependency from `build.gradle.kts`
- JSAP is not imported anywhere in the codebase but its Maven Central artifact is labeled LGPL, which is incompatible with this project's MIT license

## Test plan
- [x] CI passes (build, tests on JDK 8/11/17)
- [x] Confirmed no Java source files import `com.martiansoftware.jsap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)